### PR TITLE
fix cbld dockerfile

### DIFF
--- a/docker/cbld/Dockerfile.msopenjdk-11-jdk
+++ b/docker/cbld/Dockerfile.msopenjdk-11-jdk
@@ -1,12 +1,11 @@
 FROM sbidprod.azurecr.io/quinault
 
-RUN apt-get -qq update && \
-    apt-get -qq -y install apt-transport-https wget && \
-    wget -q https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    apt-get -qq update && \
-    apt-get -qq -y install msopenjdk-11 && \
-    apt-get -qq -y purge apt-transport-https wget && \
+RUN apt-get update && \
+    apt-get -y install apt-transport-https && \
+    echo "deb https://packages.microsoft.com/repos/cbl-d quinault-universe main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -y install msopenjdk-11 && \
+    apt-get -y purge apt-transport-https && \
     apt -y autoremove --purge && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Switches the cbld dockerfile to use the correct to use the actual cbld packages.microsoft.com repo rather than debian