### PR TITLE
update build.yml file

### DIFF
--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -4,22 +4,23 @@ trigger: none
 
 pr: none
 
-- name: jobs
-  type: object
-  # sample:
-  # cbld_11:
-  #   distro: cbld
-  #   version: 11
-  # ubuntu_11:
-  #   distro: ubuntu
-  #   version: 11
-  # cbld_16:
-  #   distro: cbld
-  #   version: 16
-  # ubuntu_16:
-  #   distro: ubuntu
-  #   version: 16
-  default: []
+parameters:
+  - name: jobs
+    type: object
+    # sample:
+    # cbld_11:
+    #   distro: cbld
+    #   version: 11
+    # ubuntu_11:
+    #   distro: ubuntu
+    #   version: 11
+    # cbld_16:
+    #   distro: cbld
+    #   version: 16
+    # ubuntu_16:
+    #   distro: ubuntu
+    #   version: 16
+    default: []
 
 jobs:
   - job: build_internal


### PR DESCRIPTION
instead ob build images when nothing changes, users need to configure the docker build `jobs` that they want to perform.

sample:

```
cbld_11:
  distro: cbld
  version: 11
ubuntu_11:
  distro: ubuntu
  version: 11
cbld_16:
  distro: cbld
  version: 16
ubuntu_16:
  distro: ubuntu
  version: 16
```

this will run all the `jdk11u: cbld, ubuntu` and `jdk16u: cbld, ubuntu`.