### PR TITLE
add binutils to jdk16 images

### DIFF
--- a/docker/cbld/Dockerfile.msopenjdk-16-jdk
+++ b/docker/cbld/Dockerfile.msopenjdk-16-jdk
@@ -1,7 +1,7 @@
 FROM sbidprod.azurecr.io/quinault
 
 RUN apt-get update && \
-    apt-get -y install apt-transport-https && \
+    apt-get -y install apt-transport-https binutils && \
     echo "deb https://packages.microsoft.com/repos/cbl-d quinault-universe main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -y install msopenjdk-16 && \

--- a/docker/ubuntu/Dockerfile.msopenjdk-16-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-16-jdk
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
 RUN apt-get -qq update && \
-    apt-get -qq -y install apt-transport-https wget && \
+    apt-get -qq -y install apt-transport-https binutils wget && \
     wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     apt-get -qq update && \


### PR DESCRIPTION
Fix taken from the official upstream openjdk docker image https://github.com/docker-library/openjdk/blob/master/16/jdk/buster/Dockerfile#L16-L18

```bash
# jlink --strip-debug on 13+ needs objcopy: https://github.com/docker-library/openjdk/issues/351# Error: java.io.IOException: Cannot run program "objcopy": error=2, No such file or directory
```