### PR TITLE
Luigi96/distroless openjdk (#30)

### DIFF
--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -37,6 +37,16 @@ parameters:
         package: msopenjdk-11
         image: "image-repository"
         tag: "'1.0'"
+      distroless_11:
+        distro: distroless
+        version: 11
+        package: msopenjdk-11
+        installer_image:
+          image: "image-repository"
+          tag: "'2.0'"
+        base_image:
+          image: "image-repository"
+          tag: "'2.0'"
       cbld_17:
         distro: cbld
         version: 17
@@ -55,6 +65,16 @@ parameters:
         package: msopenjdk-17
         image: "image-repository"
         tag: "'1.0'"
+      distroless_17:
+        distro: distroless
+        version: 17
+        package: msopenjdk-17
+        installer_image:
+          image: "image-repository"
+          tag: "'2.0'"
+        base_image:
+          image: "image-repository"
+          tag: "'2.0'"
 
 jobs:
   - job: build_internal
@@ -66,12 +86,24 @@ jobs:
     steps:
       - task: Docker@2
         displayName: build image
+        condition: and(succeeded(), ne($(distro), 'distroless'))
         inputs:
           command: build
           repository: internal/private/openjdk/jdk
           dockerfile: docker/$(distro)/Dockerfile.msopenjdk-$(version)-jdk
           containerRegistry: "msopenjdk ACR"
           arguments: --build-arg IMAGE=$(image) --build-arg TAG=$(tag) --build-arg package=$(package)
+          tags: |
+            $(version)-$(distro)
+      - task: Docker@2
+        displayName: build image
+        condition: and(succeeded(), eq($(distro), 'distroless'))
+        inputs:
+          command: build
+          repository: internal/private/openjdk/jdk
+          dockerfile: docker/$(distro)/Dockerfile.msopenjdk-$(version)-jdk
+          containerRegistry: "msopenjdk ACR"
+          arguments: --build-arg INSTALLER_IMAGE=$(installer_image.image) --build-arg INSTALLER_TAG=$(installer_image.tag) BASE_IMAGE=$(base_image.image) --build-arg BASE_TAG=$(base_image.tag) --build-arg package=$(package)
           tags: |
             $(version)-$(distro)
       - task: Docker@2
@@ -106,12 +138,24 @@ jobs:
     steps:
       - task: Docker@2
         displayName: build image
+        condition: and(succeeded(), ne($(distro), 'distroless'))
         inputs:
           command: build
           repository: public/openjdk/jdk
           dockerfile: docker/$(distro)/Dockerfile.msopenjdk-$(version)-jdk
           containerRegistry: "msopenjdk ACR"
           arguments: --build-arg IMAGE=$(image) --build-arg TAG=$(tag) --build-arg package=$(package)
+          tags: |
+            $(version)-$(distro)
+      - task: Docker@2
+        displayName: build image
+        condition: and(succeeded(), eq($(distro), 'distroless'))
+        inputs:
+          command: build
+          repository: public/openjdk/jdk
+          dockerfile: docker/$(distro)/Dockerfile.msopenjdk-$(version)-jdk
+          containerRegistry: "msopenjdk ACR"
+          arguments: --build-arg INSTALLER_IMAGE=$(installer_image.image) --build-arg INSTALLER_TAG=$(installer_image.tag) BASE_IMAGE=$(base_image.image) --build-arg BASE_TAG=$(base_image.tag) --build-arg package=$(package)
           tags: |
             $(version)-$(distro)
       - task: Docker@2

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -15,7 +15,7 @@ jobs:
     strategy: 
       matrix:
         jdkversion: [11, 16, 17]
-        baseimage: ["cbld", "mariner", "mariner-cm1", "ubuntu"]
+        baseimage: ["cbld", "mariner", "mariner-cm1", "ubuntu", "distroless"]
         include:
           - baseimage: "cbld"
             tag: latest
@@ -25,6 +25,9 @@ jobs:
             tag: "'1.0'"
           - baseimage: "ubuntu"
             tag: "20.04"
+          - baseimage: "distroless"
+            base_tag: "2.0"
+            installer_tag: "2.0"
 
     steps:
       - uses: actions/checkout@v2
@@ -46,10 +49,20 @@ jobs:
         if: ${{ matrix.baseimage == 'ubuntu' }}
         run: "echo IMAGE=${{ secrets.UBUNTU_REPO }} >> $GITHUB_ENV"
 
+      - name: Set distroless image
+        if: ${{ matrix.baseimage == 'distroless' }}
+        run: |
+         echo INSTALLER_IMAGE=${{ secrets.DISTROLESS_INSTALLER_REPO }} >> $GITHUB_ENV
+         echo BASE_IMAGE=${{ secrets.DISTROLESS_BASE_REPO }} >> $GITHUB_ENV
+
       # Runs a single command using the runners shell
       - name: Build the image
+        if: ${{ matrix.baseimage != 'distroless' }}
         run: docker build -t mcr.microsoft.com/openjdk/jdk:${{ matrix.jdkversion }}-${{ matrix.baseimage }} -f ./docker/${{ matrix.baseimage }}/Dockerfile.msopenjdk-${{ matrix.jdkversion }}-jdk ./docker/${{ matrix.baseimage }}/ --build-arg IMAGE=${{ env.IMAGE }} --build-arg TAG=${{ matrix.tag }}
 
+      - name: Build the distroless image
+        if: ${{ matrix.baseimage == 'distroless' }}
+        run: docker build -t mcr.microsoft.com/openjdk/jdk:${{ matrix.jdkversion }}-${{ matrix.baseimage }} -f ./docker/${{ matrix.baseimage }}/Dockerfile.msopenjdk-${{ matrix.jdkversion }}-jdk ./docker/${{ matrix.baseimage }}/ --build-arg INSTALLER_IMAGE=${{ env.INSTALLER_IMAGE }} --build-arg INSTALLER_TAG=${{ matrix.installer_tag }} --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} --build-arg BASE_TAG=${{ matrix.base_tag }}
   validate_images:
     runs-on: ubuntu-latest
     steps:

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -1,0 +1,36 @@
+ARG INSTALLER_IMAGE
+ARG INSTALLER_TAG
+ARG BASE_IMAGE
+ARG BASE_TAG
+
+FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
+
+ARG package=msopenjdk-11
+
+# Install msopenjdk
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+    tzdata \
+    ${package} \
+    && tdnf clean all
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+ARG package=msopenjdk-11
+
+COPY --from=installer /staging/ /
+
+ENV JAVA_HOME=/usr/lib/jvm/${package}
+
+RUN java -Xshare:dump

--- a/docker/distroless/Dockerfile.msopenjdk-16-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-16-jdk
@@ -1,0 +1,41 @@
+ARG INSTALLER_IMAGE
+ARG INSTALLER_TAG
+ARG BASE_IMAGE
+ARG BASE_TAG
+
+FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
+
+ARG package=msopenjdk-16
+
+# Install msopenjdk
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+    tzdata \
+    ca-certificates \
+    freetype \
+    fontconfig \
+    zlib \
+    && rpm -Uhv https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm \
+    && tdnf install -y --releasever=2.0 --installroot /staging ${package} --nogpgcheck \
+    && tdnf clean all
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+ARG package=msopenjdk-16
+
+COPY --from=installer /staging/ /
+
+ENV JAVA_HOME=/usr/lib/jvm/${package}
+
+RUN java -Xshare:dump

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -1,0 +1,41 @@
+ARG INSTALLER_IMAGE
+ARG INSTALLER_TAG
+ARG BASE_IMAGE
+ARG BASE_TAG
+
+FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
+
+ARG package=msopenjdk-17
+
+# Install msopenjdk
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+    tzdata \
+    ca-certificates \
+    freetype \
+    fontconfig \
+    zlib \
+    && rpm -Uhv https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm \
+    && tdnf install -y --releasever=2.0 --installroot /staging ${package} --nogpgcheck \
+    && tdnf clean all
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+ARG package=msopenjdk-17
+
+COPY --from=installer /staging/ /
+
+ENV JAVA_HOME=/usr/lib/jvm/${package}
+
+RUN java -Xshare:dump

--- a/validate-docker-images.sh
+++ b/validate-docker-images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getcmd "su" optname; do
+while getopts 'su' optname; do
   case "$optname" in
     "s")
       SKIPDELETE=1
@@ -24,7 +24,7 @@ jdk11="11.0.15"
 java_versions=("11" "16" "17")
 
 imagerepo="mcr.microsoft.com/openjdk/jdk"
-distros=("ubuntu" "cbld" "mariner")
+distros=("ubuntu" "cbld" "mariner" "distroless")
 validatedimages=()
 
 validationlog="validation-latest-images.log"
@@ -49,8 +49,13 @@ do
         validatedimages+=(${image})
         
         deleteAndPullImage $image
+
+        if [[ ${distro} -eq "distroless" ]]; then
+            java_version=$(docker run --rm $image java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')
+        else
+            java_version=$(docker run --rm $image /bin/bash -c "source \$JAVA_HOME/release && echo \$JAVA_VERSION")
+        fi
      
-        java_version=$(docker run --rm $image /bin/bash -c "source \$JAVA_HOME/release && echo \$JAVA_VERSION")
         java_version=${java_version//[$'\t\r\n']}
         java_version=${java_version%%*( )}
         


### PR DESCRIPTION
* Add distroless openjdk

* Add validation step for distroless containers

* Remove entrypoint and cmd

* Update get version of distroless image

* Remove package installation since msopenjdk-11 exist in Mariner Package Feed

* Remove base images and replace with build-args

* Fix build distroless action name and remove commented code

Co-authored-by: Luis Montoya <luiseduardom@microsoft.com>