### PR TITLE
Bump up JDK versions

### DIFF
--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "mariner-cm1", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.15" }, { major: "17", expected: "17.0.3" } ]
+        jdkversion: [ { major: "11", expected: "11.0.16" }, { major: "17", expected: "17.0.4" } ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
One call out I have is there seems to be some discrepancies between the JDK 8 distroless version actual/expected.

JDK 8 distroless has version:
openjdk version "1.8.0_342"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_342-b07)
OpenJDK 64-Bit Server VM (Temurin)(build 25.342-b07, mixed mode)

and our script expects:
openjdk version "1.8.0_332"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_332-b09)
OpenJDK 64-Bit Server VM (Temurin)(build 25.332-b09, mixed mode)

should this be updated to `1.8.0_342` ? 