### PR TITLE
Remove src.zip from images, clean up trailing whitespaces

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,7 +23,7 @@ jobs:
 
   build_msopenjdk:
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       fail-fast: false
       matrix:
         jdkversion: [11, 17] # Only build LTS releases

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Validate container image
         run: |
-          ./validate-image.sh -s ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }} 
+          ./validate-image.sh -s ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }}
 
   validate_msopenjdk:
     runs-on: ubuntu-latest
@@ -40,4 +40,4 @@ jobs:
 
       - name: Validate container image
         run: |
-          ./validate-image.sh -s ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }} 
+          ./validate-image.sh -s ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }}

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Validate container images
         run: |
-          ./validate-image.sh ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }} 
+          ./validate-image.sh ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }}
 
   validate_msopenjdk:
     runs-on: ubuntu-latest
@@ -33,4 +33,4 @@ jobs:
 
       - name: Validate container images
         run: |
-          ./validate-image.sh ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }} 
+          ./validate-image.sh ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }}

--- a/build-all-images.sh
+++ b/build-all-images.sh
@@ -12,7 +12,7 @@ basepath="$(dirname "$0")/docker"
 # Build all distros and versions of OpenJDK
 for d in $(ls -d $basepath/*); do
     distro=`basename $d`
-    
+
     if [[ "$distro" == "test-only" ]]; then
         continue
     fi
@@ -22,14 +22,14 @@ for d in $(ls -d $basepath/*); do
         jdkversion=$(echo "$dockerfile" | sed 's/[^0-9]*//g')
         image="$basemcr:${jdkversion}-${distro}"
         echo "Building image: ${image} with Dockerfile ${f}"
-        docker build -t ${image} -f ${f} ${basepath}/${distro} 
+        docker build -t ${image} -f ${f} ${basepath}/${distro}
     done
 done
 
 # Validate all distros and versions of OpenJDK
 for d in $(ls -d $basepath/*); do
     distro=`basename $d`
-    
+
     for f in $(ls -f $basepath/$distro/*); do
         dockerfile=`basename $f`
         jdkversion=$(echo "$dockerfile" | sed 's/[^0-9]*//g')

--- a/docker/mariner-cm1/Dockerfile.msopenjdk-11-jdk
+++ b/docker/mariner-cm1/Dockerfile.msopenjdk-11-jdk
@@ -17,6 +17,7 @@ RUN tdnf -y update && \
     tdnf install -y mariner-repos-ui && \
     tdnf install -y $package --nogpgcheck && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump && \
+    rm -rf /usr/lib/jvm/msopenjdk-11/lib/src.zip
 
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11

--- a/docker/mariner-cm1/Dockerfile.msopenjdk-17-jdk
+++ b/docker/mariner-cm1/Dockerfile.msopenjdk-17-jdk
@@ -17,6 +17,7 @@ RUN tdnf -y update && \
     tdnf install -y mariner-repos-ui && \
     tdnf install -y $package --nogpgcheck && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump && \
+    rm -rf /usr/lib/jvm/msopenjdk-17/lib/src.zip
 
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17

--- a/docker/mariner/Dockerfile.msopenjdk-11-jdk
+++ b/docker/mariner/Dockerfile.msopenjdk-11-jdk
@@ -14,6 +14,7 @@ RUN tdnf install -y --releasever=2.0 ${package} ${PKGS} && \
     tdnf clean all && \
     rm -rf /var/cache/tdnf && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump && \
+    rm -rf /usr/lib/jvm/msopenjdk-11/lib/src.zip
 
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11

--- a/docker/mariner/Dockerfile.msopenjdk-17-jdk
+++ b/docker/mariner/Dockerfile.msopenjdk-17-jdk
@@ -14,6 +14,7 @@ RUN rpm -Uhv https://packages.microsoft.com/config/centos/7/packages-microsoft-p
     tdnf install -y ${package} ${PKGS} && \
     rm -rf /var/cache/tdnf && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump && \
+    rm -rf /usr/lib/jvm/msopenjdk-17/lib/src.zip
 
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17

--- a/docker/mariner/Dockerfile.temurin-8-jdk
+++ b/docker/mariner/Dockerfile.temurin-8-jdk
@@ -12,6 +12,7 @@ ARG PKGS="ca-certificates tzdata freetype"
 
 # Install pre-reqs
 RUN tdnf install -y ${JDK_PKG} ${PKGS} && \
-    rm -rf /var/cache/tdnf
+    rm -rf /var/cache/tdnf && \
+    rm -rf ./usr/lib/jvm/temurin-8-jdk/src.zip
 
 ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk

--- a/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
@@ -21,7 +21,10 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump
+
+# Clean up JDK
+RUN rm -rf ./usr/lib/jvm/msopenjdk-11-amd64/lib/src.zip
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
@@ -21,10 +21,9 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     echo java -Xshare:dump && \
-    java -Xshare:dump
+    java -Xshare:dump && \
+    rm -rf ./usr/lib/jvm/msopenjdk-11-amd64/lib/src.zip
 
-# Clean up JDK
-RUN rm -rf ./usr/lib/jvm/msopenjdk-11-amd64/lib/src.zip
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
@@ -21,7 +21,10 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     echo java -Xshare:dump && \
-    java -Xshare:dump 
+    java -Xshare:dump
+
+# Clean up JDK
+RUN rm -rf ./usr/lib/jvm/msopenjdk-17-amd64/lib/src.zip
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
@@ -21,10 +21,8 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq autoremove --purge && \
     rm -rf /var/lib/apt/lists/* && \
     echo java -Xshare:dump && \
-    java -Xshare:dump
-
-# Clean up JDK
-RUN rm -rf ./usr/lib/jvm/msopenjdk-17-amd64/lib/src.zip
+    java -Xshare:dump && \
+    rm -rf ./usr/lib/jvm/msopenjdk-17-amd64/lib/src.zip
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
Addresses #38 

Also cleans up some trailing whitespaces in files.

Current:
![image](https://user-images.githubusercontent.com/106336504/189405406-d16d0509-299e-4787-8938-94ab0e8f016d.png)

With `src.zip` removed:
![image](https://user-images.githubusercontent.com/106336504/189405531-bcc74c10-8d48-4532-8b03-e018e347c1e1.png)


Not pictured temurin-8 which went from 337MB -> 285MB