### PR TITLE
clean up staging. 

### DIFF
--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -21,13 +21,14 @@ RUN mkdir /staging \
     && tdnf install -y --releasever=2.0 --installroot /staging zlib
 
 # Clean up staging
-RUN rm -rf /staging/etc/dnf \
+RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
-    && rm -rf /staging/var/cache/dnf \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && rm -rf /usr/jdk/man /usr/jdk/lib/src.zip \
     && find /staging/var/log -type f -size +0 -delete
-
-# Clean up JDK
-RUN rm -rf /usr/jdk/man /usr/jdk/lib/src.zip
 
 FROM ${BASE_IMAGE}:${BASE_TAG}
 

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -21,13 +21,14 @@ RUN mkdir /staging \
     && tdnf install -y --releasever=2.0 --installroot /staging zlib
 
 # Clean up staging
-RUN rm -rf /staging/etc/dnf \
+RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
-    && rm -rf /staging/var/cache/dnf \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && rm -rf /usr/jdk/man /usr/jdk/lib/src.zip \
     && find /staging/var/log -type f -size +0 -delete
-
-# Clean up JDK
-RUN rm -rf /usr/jdk/man /usr/jdk/lib/src.zip
 
 FROM ${BASE_IMAGE}:${BASE_TAG}
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/openjdk-docker/issues/41

Also remove extra `RUN` layer. 

Though I am seeing ~10MB difference from previous images. Entirely possible I missed an item.
![image](https://user-images.githubusercontent.com/106336504/194635258-091c0882-83b4-4ed9-9530-0b3a3954a8b0.png)

And running `-version`.
![image](https://user-images.githubusercontent.com/106336504/194635382-5739cbc5-145b-41f0-9a2d-fe8d4cdaee8e.png)
![image](https://user-images.githubusercontent.com/106336504/194635442-50fd0762-5a77-4b89-afa1-1b331a585bd9.png)


