### PR TITLE
Add automatic version updates for github actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
While checking at the Github Actions workflows of this project I noticed that some jobs use older versions of github actions.

This PR configures dependabot to automatically propose dependency updates of the github actions workflows in the project, for this to work you need to enable dependabot in the github project settings. Dependabot will create independent PRs for each individual github action update, for reference you will find the PRs that dependabot opened in my own fork.
https://github.com/iemejia/openjdk-docker/pulls
