### PR TITLE
Docker compliance

### DIFF
--- a/docker/test-only/Dockerfile.ubuntu
+++ b/docker/test-only/Dockerfile.ubuntu
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Used for testing purposes only"
 ARG IMAGE="ubuntu"
 ARG UBUNTU_VERSION="20.04"
 ARG JAVA_VERSION="17"

--- a/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Base image is obtained from internal registry"
 ARG IMAGE="ubuntu"
 ARG TAG="20.04"
 FROM ${IMAGE}:${TAG}

--- a/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Base image is obtained from internal registry"
 ARG IMAGE="ubuntu"
 ARG TAG="20.04"
 FROM ${IMAGE}:${TAG}


### PR DESCRIPTION
Disable docker scanner on Ubuntu files. When not in place the files are found to assume dockerhub (even with the suggested work around) and might result in our builds failing. We pull this base image from an internal registry and removing the default arg might result in breaking changes for customers.

This keeps the work around in place. Pull the image and retag locally. Do we want to keep it?

Let's hold off merging this one as well until @brunoborges has a change to review. Thanks.

