### PR TITLE
Simplify build-images.yml file to use the default docker args. 

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,45 +29,10 @@ jobs:
       matrix:
         jdkversion: [11, 17] # Only build LTS releases
         baseimage: ["mariner", "mariner-cm1", "ubuntu", "distroless"]
-        include:
-          - baseimage: "mariner"
-            tag: "'2.0'"
-          - baseimage: "mariner-cm1"
-            tag: "'1.0'"
-          - baseimage: "ubuntu"
-            tag: "20.04"
-          - baseimage: "distroless"
-            base_tag: "2.0"
-            installer_tag: "2.0"
 
     steps:
       - uses: actions/checkout@v3
 
-      # Note: Using secrets will not work with forked pull requests
-      - name: Set mariner 2.0 image
-        if: ${{ matrix.baseimage == 'mariner' }}
-        run: "echo IMAGE=${{ secrets.MARINER_REPO }} >> $GITHUB_ENV"
-
-      - name: Set mariner 1.0 image
-        if: ${{ matrix.baseimage == 'mariner-cm1' }}
-        run: "echo IMAGE=${{ secrets.MARINER_CM1_REPO }} >> $GITHUB_ENV"
-
-      - name: Set ubuntu image
-        if: ${{ matrix.baseimage == 'ubuntu' }}
-        run: "echo IMAGE=${{ secrets.UBUNTU_REPO }} >> $GITHUB_ENV"
-
-      - name: Set distroless image
-        if: ${{ matrix.baseimage == 'distroless' }}
-        run: |
-         echo INSTALLER_IMAGE=${{ secrets.DISTROLESS_INSTALLER_REPO }} >> $GITHUB_ENV
-         echo BASE_IMAGE=${{ secrets.DISTROLESS_BASE_REPO }} >> $GITHUB_ENV
-
       # Runs a single command using the runners shell
       - name: Build the image
-        if: ${{ matrix.baseimage != 'distroless' }}
-        run: docker build -t mcr.microsoft.com/openjdk/jdk:${{ matrix.jdkversion }}-${{ matrix.baseimage }} -f ./docker/${{ matrix.baseimage }}/Dockerfile.msopenjdk-${{ matrix.jdkversion }}-jdk ./docker/${{ matrix.baseimage }}/ --build-arg IMAGE=${{ env.IMAGE }} --build-arg TAG=${{ matrix.tag }}
-
-      - name: Build the distroless image
-        if: ${{ matrix.baseimage == 'distroless' }}
-        run: docker build -t mcr.microsoft.com/openjdk/jdk:${{ matrix.jdkversion }}-${{ matrix.baseimage }} -f ./docker/${{ matrix.baseimage }}/Dockerfile.msopenjdk-${{ matrix.jdkversion }}-jdk ./docker/${{ matrix.baseimage }}/ --build-arg INSTALLER_IMAGE=${{ env.INSTALLER_IMAGE }} --build-arg INSTALLER_TAG=${{ matrix.installer_tag }} --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} --build-arg BASE_TAG=${{ matrix.base_tag }}
-
+        run: docker build -t mcr.microsoft.com/openjdk/jdk:${{ matrix.jdkversion }}-${{ matrix.baseimage }} -f ./docker/${{ matrix.baseimage }}/Dockerfile.msopenjdk-${{ matrix.jdkversion }}-jdk ./docker/${{ matrix.baseimage }}/


### PR DESCRIPTION
In a previous [PR](https://github.com/microsoft/openjdk-docker/pull/53/files) we resolved which default images should be using the correct base images for our outward facing docker files.

This change updates the build-images.yml to use the default args instead of secrets set on the repository. Since the action is to validate the images can be built using the default `ubuntu:20.04` image from **docker hub** should be ok.

Please let me know if there are any issues with this change. If the change is acceptable, we can also remove some of the secrets set for GH actions from the repo.