### PR TITLE
Add non-root user 'app' to all images

### DIFF
--- a/build-all-images.sh
+++ b/build-all-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set expected JDK versions after the images are built
-declare -A jdkversions=( ["11"]="11.0.15" ["17"]="17.0.3" ["8"]="1.8.0_332" )
+declare -A jdkversions=( ["11"]="11.0.17" ["17"]="17.0.5" ["8"]="1.8.0_352" )
 
 # Set the base MCR repo
 basemcr="mcr.microsoft.com/openjdk/jdk"

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -20,6 +20,15 @@ RUN mkdir -p /usr/lib/jvm && \
 RUN mkdir /staging \
     && tdnf install -y --releasever=2.0 --installroot /staging zlib
 
+# Create a non-root user and group (just like .NET's image)
+RUN tdnf install -y gawk shadow-utils \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
@@ -37,6 +46,7 @@ LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
 
 COPY --from=installer /staging/ /
 COPY --from=installer /usr/jdk/ /usr/jdk/
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
 ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -20,6 +20,15 @@ RUN mkdir -p /usr/lib/jvm && \
 RUN mkdir /staging \
     && tdnf install -y --releasever=2.0 --installroot /staging zlib
 
+# Create a non-root user and group (just like .NET's image)
+RUN tdnf install -y gawk shadow-utils \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
@@ -37,6 +46,7 @@ LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
 
 COPY --from=installer /staging/ /
 COPY --from=installer /usr/jdk/ /usr/jdk/
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
 ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -9,7 +9,8 @@ ARG PKGS="ca-certificates tzdata freetype"
 ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
 # Create a non-root user and group (just like .NET's image)
-RUN tdnf install -y gawk shadow-utils \
+RUN mkdir /staging \
+    && tdnf install -y gawk shadow-utils \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -8,6 +8,15 @@ FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 ARG PKGS="ca-certificates tzdata freetype"
 ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
+# Create a non-root user and group (just like .NET's image)
+RUN tdnf install -y gawk shadow-utils \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
 # Install pre-reqs
 RUN mkdir -p /usr/lib/jvm && \
     tdnf install -y ca-certificates tar && \
@@ -25,5 +34,6 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 COPY --from=installer /usr/jdk/ /usr/jdk/
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -9,7 +9,7 @@ ARG PKGS="ca-certificates tzdata freetype"
 ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
 # Create a non-root user and group (just like .NET's image)
-RUN mkdir /staging \
+RUN mkdir -p /staging/etc/ \
     && tdnf install -y gawk shadow-utils \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/mariner-cm1/Dockerfile.msopenjdk-11-jdk
+++ b/docker/mariner-cm1/Dockerfile.msopenjdk-11-jdk
@@ -20,4 +20,10 @@ RUN tdnf -y update && \
     java -Xshare:dump && \
     rm -rf /usr/lib/jvm/msopenjdk-11/lib/src.zip
 
+RUN tdnf install -y gawk shadow-utils \
+    && tdnf clean all \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11

--- a/docker/mariner-cm1/Dockerfile.msopenjdk-17-jdk
+++ b/docker/mariner-cm1/Dockerfile.msopenjdk-17-jdk
@@ -20,4 +20,10 @@ RUN tdnf -y update && \
     java -Xshare:dump && \
     rm -rf /usr/lib/jvm/msopenjdk-17/lib/src.zip
 
+RUN tdnf install -y gawk shadow-utils \
+    && tdnf clean all \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17

--- a/docker/mariner/Dockerfile.msopenjdk-11-jdk
+++ b/docker/mariner/Dockerfile.msopenjdk-11-jdk
@@ -17,4 +17,10 @@ RUN tdnf install -y --releasever=2.0 ${package} ${PKGS} && \
     java -Xshare:dump && \
     rm -rf /usr/lib/jvm/msopenjdk-11/lib/src.zip
 
+RUN tdnf install -y gawk shadow-utils \
+    && tdnf clean all \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11

--- a/docker/mariner/Dockerfile.msopenjdk-17-jdk
+++ b/docker/mariner/Dockerfile.msopenjdk-17-jdk
@@ -17,4 +17,10 @@ RUN rpm -Uhv https://packages.microsoft.com/config/centos/7/packages-microsoft-p
     java -Xshare:dump && \
     rm -rf /usr/lib/jvm/msopenjdk-17/lib/src.zip
 
+RUN tdnf install -y gawk shadow-utils \
+    && tdnf clean all \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17

--- a/docker/mariner/Dockerfile.temurin-8-jdk
+++ b/docker/mariner/Dockerfile.temurin-8-jdk
@@ -15,4 +15,10 @@ RUN tdnf install -y ${JDK_PKG} ${PKGS} && \
     rm -rf /var/cache/tdnf && \
     rm -rf ./usr/lib/jvm/temurin-8-jdk/src.zip
 
+RUN tdnf install -y gawk shadow-utils \
+    && tdnf clean all \
+    && groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk

--- a/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-11-jdk
@@ -25,6 +25,9 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     java -Xshare:dump && \
     rm -rf ./usr/lib/jvm/msopenjdk-11-amd64/lib/src.zip
 
+RUN groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-17-jdk
@@ -25,6 +25,10 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     java -Xshare:dump && \
     rm -rf ./usr/lib/jvm/msopenjdk-17-amd64/lib/src.zip
 
+RUN groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-17-amd64


### PR DESCRIPTION
This PR adds a non-root user, named `app`.
Consumers of the image may choose to run Java applications with a non-root user.
By default, the image still runs as `root`.

Example of a consuming Dockefile:

```dockerfile
FROM mcr.microsoft.com/openjdk/jdk:17-distroless
ADD target/myapp.jar /myapp.jar
USER app
CMD ["-jar", "/myapp.jar"]
```