### PR TITLE
Revert mariner/temurin-8 package env var

### DIFF
--- a/docker/mariner/Dockerfile.temurin-8-jdk
+++ b/docker/mariner/Dockerfile.temurin-8-jdk
@@ -5,17 +5,17 @@ FROM ${IMAGE}:${TAG}
 LABEL "Author"="Microsoft"
 LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
 
-ARG package="temurin-8-jdk"
+ARG JDK_PKG="temurin-8-jdk"
 ARG PKGS="tzdata ca-certificates freetype shadow-utils"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk
 
 # Install pre-reqs
-RUN tdnf install -y ${package} ${PKGS} && \
+RUN tdnf install -y ${JDK_PKG} ${PKGS} && \
     tdnf clean all && \
     groupadd --system --gid=101 app && \
     adduser --uid 101 --gid 101 --system app && \
     install -d -m 0755 -o 101 -g 101 "/home/app" && \
     rm -rf /var/cache/tdnf && \
-    rm -rf ./usr/lib/jvm/${package}/src.zip
+    rm -rf ./usr/lib/jvm/${JDK_PKG}/src.zip


### PR DESCRIPTION
This change is to revert a change made in #60 to the `JDK_PKG`. `JDK_PKG` was changed to `package` however since the temurin 8 package has a `-jdk` appended to its name this breaks our `docker build` stage. Our msopenjdk packages do not have that value appened to their names (e.g. `msopenjdk-17`). Keeping the change as it was before does indeed fix the build stage. 

If the idea is to align all environment variables between the docker files that will require changes for our `build.yml` in order to work as intended.