### PR TITLE
Update Microsofts Build of OpenJDK versions to 11.0.18 and 17.0.6

### DIFF
--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "mariner-cm1", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.17" }, { major: "17", expected: "17.0.5" } ]
+        jdkversion: [ { major: "11", expected: "11.0.18" }, { major: "17", expected: "17.0.6" } ]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This change updates the versions of Microsoft's build of OpenJDK to the current LTS versions.