### PR TITLE
Add support for linux arm

### DIFF
--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless" ]
         jdkvendor: [ "temurin" ]
-        jdkversion: [ { major: "8", expected: "1.8.0_352" } ]
+        jdkversion: [ { major: "8", expected: "1.8.0_362" } ]
     steps:
       - uses: actions/checkout@v3
 
@@ -22,6 +22,21 @@ jobs:
 
   validate_msopenjdk:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distros: [ "mariner", "distroless", "mariner-cm1", "ubuntu" ]
+        jdkvendor: [ "msopenjdk" ]
+        jdkversion: [ { major: "11", expected: "11.0.18" }, { major: "17", expected: "17.0.6" } ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Validate container images
+        run: |
+          ./validate-image.sh ${{ matrix.distros }} ${{ matrix.jdkvendor }} ${{ matrix.jdkversion.major }} ${{ matrix.jdkversion.expected }}
+
+  validate_msopenjdk_aarch64:
+    runs-on: ['self-hosted', '1ES.Pool=JEG-linux-arm64-openjdk-docker']
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds support to validate Linux ARM64 container images. Also, bumps up temurin-8 jdk version.

[Test run here](https://github.com/microsoft/openjdk-docker/actions/runs/4430525870).