### PR TITLE
Add CDS check

### DIFF
--- a/validate-image.sh
+++ b/validate-image.sh
@@ -61,5 +61,18 @@ if [[ ! -z "$expectedversion" ]]; then
   fi
 fi
 
+# Check if CDS is enabled
+if [[ "${distro}" == "distroless" ]]; then
+    java_version_string=$(docker run --rm $image -version 2>&1)
+else
+    java_version_string=$(docker run --rm $image /bin/bash -c "java -version 2>&1")
+fi
+
+if [[ "$java_version_string" =~ "sharing" ]]; then
+    echo "::notice title=CDS enabled ($jdkversion-$distro)::Image '${image}' has enabled CDS."
+else
+    echo "::warning title=CDS disabled ($jdkversion-$distro)::Image '${image}' has disabled CDS."
+fi
+
 # Run tests
 bash test-image.sh $distro $jdkversion


### PR DESCRIPTION
Adds in a simple test to check if CDS is enabled for our images. This is done by checking if the version string contains "sharing". If that is not found then a warning is sent to the logs. I am not sure if we want to fail the check if CDS is disabled. 


[Example workflow run](https://github.com/microsoft/openjdk-docker/actions/runs/4504176093)

Example warning:
![image](https://user-images.githubusercontent.com/106336504/227320198-965e66b8-8709-4b45-9eb4-89f87310df8c.png)

