### PR TITLE
Adding locale environment variables

### DIFF
--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -52,6 +52,7 @@ COPY --from=installer /staging/ /
 COPY --from=installer /usr/jdk/ /usr/jdk/
 COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -52,6 +52,7 @@ COPY --from=installer /staging/ /
 COPY --from=installer /usr/jdk/ /usr/jdk/
 COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -52,6 +52,7 @@ COPY --from=installer /staging/ /
 COPY --from=installer /usr/jdk/ /usr/jdk/
 COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 


### PR DESCRIPTION
Per the suggestion in [this issue](https://github.com/microsoft/openjdk-docker/issues/85). We would like to add the environment present variables present in non-distroless images to our distroless images.

Let's be sure that the variables are present in the correct layer 😉 . Running `docker image inspect <IMAGE>`  I believe that these variables should be present as expected.

See below:

![image](https://github.com/microsoft/openjdk-docker/assets/106336504/f2ac5d93-b397-4ba3-ba08-33cee890ae34)
