### PR TITLE
Bump java versions

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.21" }, { major: "17", expected: "17.0.9" }, { major: "21", expected: "21.0.1" } ]
+        jdkversion: [ { major: "11", expected: "11.0.22" }, { major: "17", expected: "17.0.10" }, { major: "21", expected: "21.0.2" } ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.21" }, { major: "17", expected: "17.0.9" }, { major: "21", expected: "21.0.1" } ]
+        jdkversion: [ { major: "11", expected: "11.0.22" }, { major: "17", expected: "17.0.10" }, { major: "21", expected: "21.0.2" } ]
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +42,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.21" }, { major: "17", expected: "17.0.9" }, { major: "21", expected: "21.0.1" } ]
+        jdkversion: [ { major: "11", expected: "11.0.22" }, { major: "17", expected: "17.0.10" }, { major: "21", expected: "21.0.2" } ]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Bump MS OpenJDK Java versions. JDK 8 was left unchanged since we are waiting for Temurin to drop the installers. We can include those in this change, if that is what we desire.