### PR TITLE
Update validate-publish-images.yml to expect new Oct2024PSU JDKs

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         distros: [ "mariner", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.22" }, { major: "17", expected: "17.0.10" }, { major: "21", expected: "21.0.2" } ]
+        jdkversion: [ { major: "11", expected: "11.0.25" }, { major: "17", expected: "17.0.13" }, { major: "21", expected: "21.0.5" } ]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -59,9 +59,9 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.24" },
-            { major: "17", expected: "17.0.12" },
-            { major: "21", expected: "21.0.4" },
+            { major: "11", expected: "11.0.25" },
+            { major: "17", expected: "17.0.13" },
+            { major: "21", expected: "21.0.5" },
           ]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -35,9 +35,9 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.24" },
-            { major: "17", expected: "17.0.12" },
-            { major: "21", expected: "21.0.4" },
+            { major: "11", expected: "11.0.25" },
+            { major: "17", expected: "17.0.13" },
+            { major: "21", expected: "21.0.5" },
           ]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
This updates the docker image validator to check for the new versions of our JDKs.

Note: The jdk8 distroless check currently fails. This is because the update method for distroless and for mariner 8 are different, and [upstream](https://packages.adoptium.net/ui/native/rpm/centos/7/x86_64/Packages/) has not currently published jdk8 version 1.8.0.432 RPM files yet. Will update this repo (and the docker images) when those files are released

Successful run: https://github.com/microsoft/openjdk-docker/actions/runs/11466231661