### PR TITLE
Distroless with Azure Linux 3.0

### DIFF
--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -19,8 +19,8 @@ RUN mkdir /staging \
     && tdnf update -y \
     && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --gid=101 app \
-    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
+    && groupadd --system --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
     && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -1,25 +1,29 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="11"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-11-linux-ARCH.tar.gz"
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && groupadd --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -31,7 +35,7 @@ RUN mkdir -p /usr/lib/jvm && \
     curl --silent -L ${JDK_URL} -o /jdk.tar.gz && \
     tar -xzf /jdk.tar.gz -C / && \
     rm /jdk.tar.gz && \
-    mv /jdk-1* /usr/jdk
+    mv /jdk-2* /usr/jdk
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \
@@ -57,3 +61,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -35,7 +35,7 @@ RUN mkdir -p /usr/lib/jvm && \
     curl --silent -L ${JDK_URL} -o /jdk.tar.gz && \
     tar -xzf /jdk.tar.gz -C / && \
     rm /jdk.tar.gz && \
-    mv /jdk-2* /usr/jdk
+    mv /jdk-1* /usr/jdk
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -19,8 +19,8 @@ RUN mkdir /staging \
     && tdnf update -y \
     && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --gid=101 app \
-    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
+    && groupadd --system --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
     && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -1,25 +1,29 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="17"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-17-linux-ARCH.tar.gz"
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && groupadd --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -31,7 +35,7 @@ RUN mkdir -p /usr/lib/jvm && \
     curl --silent -L ${JDK_URL} -o /jdk.tar.gz && \
     tar -xzf /jdk.tar.gz -C / && \
     rm /jdk.tar.gz && \
-    mv /jdk-1* /usr/jdk
+    mv /jdk-2* /usr/jdk
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \
@@ -57,3 +61,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -35,7 +35,7 @@ RUN mkdir -p /usr/lib/jvm && \
     curl --silent -L ${JDK_URL} -o /jdk.tar.gz && \
     tar -xzf /jdk.tar.gz -C / && \
     rm /jdk.tar.gz && \
-    mv /jdk-2* /usr/jdk
+    mv /jdk-1* /usr/jdk
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -19,8 +19,8 @@ RUN mkdir /staging \
     && tdnf update -y \
     && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --gid=101 app \
-    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
+    && groupadd --system --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
     && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -1,4 +1,5 @@
 ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="21"
 ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
 ARG INSTALLER_TAG="${LINUX_VERSION}"
 ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
@@ -8,8 +9,8 @@ FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
 # Redeclare ARG to make it available in this build stage
 ARG INSTALLER_TAG
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-21-linux-ARCH.tar.gz"
-ENV INSTALLER_TAG="${INSTALLER_TAG}"
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -1,25 +1,28 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG LINUX_VERSION="3.0"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
 ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-21-linux-ARCH.tar.gz"
+ENV INSTALLER_TAG="${INSTALLER_TAG}"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
-    && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && groupadd --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -57,3 +60,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -1,18 +1,22 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="8"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/ARCH/jdk/hotspot/normal/eclipse?project=jdk"
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ga/linux/ARCH/jdk/hotspot/normal/eclipse?project=jdk"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG}} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \
@@ -56,3 +60,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -16,7 +16,7 @@ ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ga/linux/A
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=${INSTALLER_TAG}} --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -19,7 +19,7 @@ RUN mkdir /staging \
     && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && adduser --uid 101 --gid 101 --shell /bin/false --system --create-home app \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \


### PR DESCRIPTION
## Pull Request Overview

This PR updates the distroless Dockerfiles to use Azure Linux 3.0 and to parameterize the base JDK version and URL.  
- Switch base and installer images to Azure Linux 3.0  
- Introduce LINUX_VERSION and JDK_VERSION arguments and update JDK_URL accordingly  
- Add a default CMD ["-version"] and adjust the non-root user/group setup

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated no comments.

| File                                               | Description                                                             |
| -------------------------------------------------- | ----------------------------------------------------------------------- |
| docker/distroless/Dockerfile.temurin-8-jdk           | Updated image/tag args, parameterized JDK URL, and updated user creation |
| docker/distroless/Dockerfile.msopenjdk-21-jdk         | Updated image/tag args, parameterized JDK URL, and adjusted user creation |
| docker/distroless/Dockerfile.msopenjdk-17-jdk         | Updated image/tag args, parameterized JDK URL, and adjusted user creation |
| docker/distroless/Dockerfile.msopenjdk-11-jdk         | Updated image/tag args, parameterized JDK URL, and adjusted user creation |


<details>
<summary>Comments suppressed due to low confidence (1)</summary>

**docker/distroless/Dockerfile.temurin-8-jdk:22**
* [nitpick] Consider using the same user creation command (e.g. 'useradd') as in the other Dockerfiles for consistency, if the base image supports it.
```
&& adduser --uid 101 --gid 101 --shell /bin/false --system --create-home app
```
</details>

