### PR TITLE
Deprecate Mariner 2.0

### DIFF
--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -271,30 +271,15 @@ extends:
                   scriptType: "bash"
                   scriptLocation: "inlineScript"
                   inlineScript: |
+                    TAGS="$(version)-$(distro)"
+                    if [[ "$(distro)". == "azurelinux" ]]; then
+                      TAGS+=", $(version)-mariner"
+                    fi
                     az pipelines run \
                       --branch main \
                       --org ${{ parameters.organization }} \
                       --project $(OPENJDK_PROJECT) \
                       --id $(OPENJDK_SIGNING_ID) \
-                      --parameters openjdk_tags="- $(version)-$(distro)" \
+                      --parameters openjdk_tags="[${TAGS}]" \
                         image_registry="msopenjdk.azurecr.io/public/openjdk" \
                         image_name="jdk"
-
-              - ${{ if eq(variables.distro, 'azurelinux') }}:
-                - task: AzureCLI@2
-                  displayName: Trigger image signing for mariner
-                  env:
-                    AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-                  inputs:
-                    azureSubscription: "JEG-Infrastructure"
-                    scriptType: "bash"
-                    scriptLocation: "inlineScript"
-                    inlineScript: |
-                      az pipelines run \
-                        --branch main \
-                        --org ${{ parameters.organization }} \
-                        --project $(OPENJDK_PROJECT) \
-                        --id $(OPENJDK_SIGNING_ID) \
-                        --parameters openjdk_tags="- $(version)-mariner" \
-                          image_registry="msopenjdk.azurecr.io/public/openjdk" \
-                          image_name="jdk"

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -152,6 +152,14 @@ extends:
                   FEED: ${{ parameters.feed }}
                   NAME: ${{ parameters.package }}
 
+              - bash: |
+                  REGISTRIES=msopenjdk.azurecr.io/internal/private/openjdk/jdk:${version)-$(distro)
+                  if [[ "$(distro)" == "azurelinux" ]]; then
+                    REGISTRIES+=";msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner"
+                  fi
+                  echo "##vso[task.setvariable variable=REGISTRIES]$REGISTRIES"
+                displayName: Set REGISTRIES variable
+
               - task: AzureCLI@2
                 displayName: Annotate previous image
                 condition: ne( variables['new_LTS_image'], true)
@@ -162,7 +170,7 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/image-annotation.sh
                 env:
                   ACR_NAME: msopenjdk
-                  REGISTRY: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
+                  REGISTRIES: $(REGISTRIES)
               - task: AzureCLI@2
                 inputs:
                   azureSubscription: "JEG-Infrastructure"
@@ -171,7 +179,7 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/build-image.sh
                 displayName: build image
                 env:
-                  REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)$[ if eq(variables['distro'], 'azurelinux'), ';msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner' ]
+                  REGISTRY_TAGS: $(REGISTRIES)
                   IMAGE: $(image)
                   TAG: $(tag)
                   PACKAGE: $(package)
@@ -218,6 +226,14 @@ extends:
                   FEED: ${{ parameters.feed }}
                   NAME: ${{ parameters.package }}
 
+              - bash: |
+                  REGISTRIES=msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  if [[ "$(distro)" == "azurelinux" ]]; then
+                    REGISTRIES+=";msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner"
+                  fi
+                  echo "##vso[task.setvariable variable=REGISTRIES]$REGISTRIES"
+                displayName: Set REGISTRIES variable
+
               - task: AzureCLI@2
                 displayName: Annotate previous image
                 condition: ne( variables['new_LTS_image'], true)
@@ -228,10 +244,7 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/image-annotation.sh
                 env:
                   ACR_NAME: msopenjdk
-                  ${{ if eq(variables.distro, 'azurelinux') }}:
-                    REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
-                  ${{ else }}:
-                    REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  REGISTRIES: $(REGISTRIES)
 
               - task: AzureCLI@2
                 inputs:
@@ -241,10 +254,7 @@ extends:
                   scriptPath: scripts/build-image.sh
                 displayName: build image
                 env:
-                  ${{ if eq(variables.distro, 'azurelinux') }}:
-                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
-                  ${{ else }}:
-                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  REGISTRY_TAGS: $(REGISTRIES)
                   IMAGE: $(image)
                   TAG: $(tag)
                   PACKAGE: $(package)

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -45,9 +45,9 @@ parameters:
         version: 8
         package: temurin-8
         installer_image: "image-repository"
-        installer_tag: "2.0"
+        installer_tag: "3.0"
         base_image: "image-repository"
-        base_tag: "2.0"
+        base_tag: "3.0"
       ubuntu_11:
         new_LTS_image: false
         distro: ubuntu
@@ -75,9 +75,9 @@ parameters:
         version: 11
         package: msopenjdk-11
         installer_image: "image-repository"
-        installer_tag: "2.0"
+        installer_tag: "3.0"
         base_image: "image-repository"
-        base_tag: "2.0"
+        base_tag: "3.0"
       ubuntu_17:
         new_LTS_image: false
         distro: ubuntu
@@ -105,9 +105,9 @@ parameters:
         version: 17
         package: msopenjdk-17
         installer_image: "image-repository"
-        installer_tag: "2.0"
+        installer_tag: "3.0"
         base_image: "image-repository"
-        base_tag: "2.0"
+        base_tag: "3.0"
       ubuntu_21:
         new_LTS_image: false
         distro: ubuntu
@@ -135,9 +135,9 @@ parameters:
         version: 21
         package: msopenjdk-21
         installer_image: "image-repository"
-        installer_tag: "2.0"
+        installer_tag: "3.0"
         base_image: "image-repository"
-        base_tag: "2.0"
+        base_tag: "3.0"
 
 resources:
   repositories:

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -230,13 +230,16 @@ extends:
 
               - bash: |
                   REGISTRIES=msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  TAGS="$(version)-$(distro)"
                   if [[ "$(distro)" == "azurelinux" ]]; then
                     REGISTRIES+=";msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner"
                   elif [[ "$(distro)" == "mariner" ]]; then
                     REGISTRIES="msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner-cm2"
+                    TAGS="$(version)-mariner-cm2"
                   fi
                   echo "##vso[task.setvariable variable=REGISTRIES]$REGISTRIES"
-                displayName: Set REGISTRIES variable
+                  echo "##vso[task.setvariable variable=TAGS]$TAGS"
+                displayName: Set environment variables
 
               - task: AzureCLI@2
                 displayName: Annotate previous image
@@ -275,15 +278,11 @@ extends:
                   scriptType: "bash"
                   scriptLocation: "inlineScript"
                   inlineScript: |
-                    TAGS="$(version)-$(distro)"
-                    if [[ "$(distro)" == "mariner" ]]; then
-                      TAGS="$(version)-mariner-cm2"
-                    fi
                     az pipelines run \
                       --branch main \
                       --org ${{ parameters.organization }} \
                       --project $(OPENJDK_PROJECT) \
                       --id $(OPENJDK_SIGNING_ID) \
-                      --parameters openjdk_tags="[${TAGS}]" \
+                      --parameters openjdk_tags="[$(TAGS)]" \
                         image_registry="msopenjdk.azurecr.io/public/openjdk" \
                         image_name="jdk"

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -32,13 +32,6 @@ parameters:
         package: temurin-8
         image: "image-repository"
         tag: "3.0"
-      # mariner_8:
-      #   new_LTS_image: false
-      #   distro: mariner
-      #   version: 8
-      #   package: temurin-8
-      #   image: "image-repository"
-      #   tag: "2.0"
       distroless_8:
         new_LTS_image: false
         distro: distroless
@@ -62,13 +55,6 @@ parameters:
         package: msopenjdk-11
         image: "image-repository"
         tag: "3.0"
-      # mariner_11:
-      #   new_LTS_image: false
-      #   distro: mariner
-      #   version: 11
-      #   package: msopenjdk-11
-      #   image: "image-repository"
-      #   tag: "2.0"
       distroless_11:
         new_LTS_image: false
         distro: distroless
@@ -92,13 +78,6 @@ parameters:
         package: msopenjdk-17
         image: "image-repository"
         tag: "3.0"
-      # mariner_17:
-      #   new_LTS_image: false
-      #   distro: mariner
-      #   version: 17
-      #   package: msopenjdk-17
-      #   image: "image-repository"
-      #   tag: "2.0"
       distroless_17:
         new_LTS_image: false
         distro: distroless
@@ -122,13 +101,6 @@ parameters:
         package: msopenjdk-21
         image: "image-repository"
         tag: "3.0"
-      # mariner_21:
-      #   new_LTS_image: false
-      #   distro: mariner
-      #   version: 21
-      #   package: msopenjdk-21
-      #   image: "image-repository"
-      #   tag: "2.0"
       distroless_21:
         new_LTS_image: false
         distro: distroless
@@ -201,9 +173,6 @@ extends:
                 env:
                   $[ if eq(variables.distro, 'azurelinux') ]:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner
-                  # Mariner is reaching EOL, this will be removed in July 2025
-                  # $[ elseif eq(variables.distro, 'mariner') ]:
-                  #   REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner-cm2
                   $[ else ]:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)
@@ -278,9 +247,6 @@ extends:
                   REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
                   $[ if eq(variables.distro, 'azurelinux') ]:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
-                  # Mariner is reaching EOL, this will be removed in July 2025
-                  # $[ elseif eq(variables.distro, 'mariner') ]:
-                  #   REGISTRY_TAGS: REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner-cm2
                   $[ else ]:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -156,6 +156,8 @@ extends:
                   REGISTRIES=msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   if [[ "$(distro)" == "azurelinux" ]]; then
                     REGISTRIES+=";msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner"
+                  elif [[ "$(distro)" == "mariner" ]]; then
+                    REGISTRIES="msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner-cm2"
                   fi
                   echo "##vso[task.setvariable variable=REGISTRIES]$REGISTRIES"
                 displayName: Set REGISTRIES variable
@@ -230,6 +232,8 @@ extends:
                   REGISTRIES=msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
                   if [[ "$(distro)" == "azurelinux" ]]; then
                     REGISTRIES+=";msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner"
+                  elif [[ "$(distro)" == "mariner" ]]; then
+                    REGISTRIES="msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner-cm2"
                   fi
                   echo "##vso[task.setvariable variable=REGISTRIES]$REGISTRIES"
                 displayName: Set REGISTRIES variable
@@ -274,6 +278,8 @@ extends:
                     TAGS="$(version)-$(distro)"
                     if [[ "$(distro)". == "azurelinux" ]]; then
                       TAGS+=", $(version)-mariner"
+                    elif [[ "$(distro)" == "mariner" ]]; then
+                      TAGS="$(version)-mariner-cm2"
                     fi
                     az pipelines run \
                       --branch main \

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -276,9 +276,7 @@ extends:
                   scriptLocation: "inlineScript"
                   inlineScript: |
                     TAGS="$(version)-$(distro)"
-                    if [[ "$(distro)". == "azurelinux" ]]; then
-                      TAGS+=", $(version)-mariner"
-                    elif [[ "$(distro)" == "mariner" ]]; then
+                    if [[ "$(distro)" == "mariner" ]]; then
                       TAGS="$(version)-mariner-cm2"
                     fi
                     az pipelines run \

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -171,10 +171,7 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/build-image.sh
                 displayName: build image
                 env:
-                  ${{ if eq(variables.distro, 'azurelinux') }}:
-                    REGISTRY_TAGS: test
-                  ${{ else }}:
-                    REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
+                  REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)$[ if eq(variables['distro'], 'azurelinux'), ';msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner' ]
                   IMAGE: $(image)
                   TAG: $(tag)
                   PACKAGE: $(package)

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -153,7 +153,7 @@ extends:
                   NAME: ${{ parameters.package }}
 
               - bash: |
-                  REGISTRIES=msopenjdk.azurecr.io/internal/private/openjdk/jdk:${version)-$(distro)
+                  REGISTRIES=msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   if [[ "$(distro)" == "azurelinux" ]]; then
                     REGISTRIES+=";msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner"
                   fi

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -171,9 +171,9 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/build-image.sh
                 displayName: build image
                 env:
-                  $[ if eq(variables.distro, 'azurelinux') ]:
+                  ${{ if eq(variables.distro, 'azurelinux') }}:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner
-                  $[ else ]:
+                  ${{ else }}:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)
                   TAG: $(tag)
@@ -231,9 +231,9 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/image-annotation.sh
                 env:
                   ACR_NAME: msopenjdk
-                  $[ if eq(variables.distro, 'azurelinux') ]:
+                  ${{ if eq(variables.distro, 'azurelinux') }}:
                     REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
-                  $[ else ]:
+                  ${{ else }}:
                     REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
 
               - task: AzureCLI@2
@@ -244,10 +244,9 @@ extends:
                   scriptPath: scripts/build-image.sh
                 displayName: build image
                 env:
-                  REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
-                  $[ if eq(variables.distro, 'azurelinux') ]:
-                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
-                  $[ else ]:
+                  ${{ if eq(variables.distro, 'azurelinux') }}:
+                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
+                  ${{ else }}:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)
                   TAG: $(tag)
@@ -274,7 +273,7 @@ extends:
                         image_registry="msopenjdk.azurecr.io/public/openjdk" \
                         image_name="jdk"
 
-               - $[ if eq(variables.distro, 'azurelinux') ]:
+              - ${{ if eq(variables.distro, 'azurelinux') }}:
                 - task: AzureCLI@2
                   displayName: Trigger image signing for mariner
                   env:

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -32,13 +32,13 @@ parameters:
         package: temurin-8
         image: "image-repository"
         tag: "3.0"
-      mariner_8:
-        new_LTS_image: false
-        distro: mariner
-        version: 8
-        package: temurin-8
-        image: "image-repository"
-        tag: "2.0"
+      # mariner_8:
+      #   new_LTS_image: false
+      #   distro: mariner
+      #   version: 8
+      #   package: temurin-8
+      #   image: "image-repository"
+      #   tag: "2.0"
       distroless_8:
         new_LTS_image: false
         distro: distroless
@@ -62,13 +62,13 @@ parameters:
         package: msopenjdk-11
         image: "image-repository"
         tag: "3.0"
-      mariner_11:
-        new_LTS_image: false
-        distro: mariner
-        version: 11
-        package: msopenjdk-11
-        image: "image-repository"
-        tag: "2.0"
+      # mariner_11:
+      #   new_LTS_image: false
+      #   distro: mariner
+      #   version: 11
+      #   package: msopenjdk-11
+      #   image: "image-repository"
+      #   tag: "2.0"
       distroless_11:
         new_LTS_image: false
         distro: distroless
@@ -92,13 +92,13 @@ parameters:
         package: msopenjdk-17
         image: "image-repository"
         tag: "3.0"
-      mariner_17:
-        new_LTS_image: false
-        distro: mariner
-        version: 17
-        package: msopenjdk-17
-        image: "image-repository"
-        tag: "2.0"
+      # mariner_17:
+      #   new_LTS_image: false
+      #   distro: mariner
+      #   version: 17
+      #   package: msopenjdk-17
+      #   image: "image-repository"
+      #   tag: "2.0"
       distroless_17:
         new_LTS_image: false
         distro: distroless
@@ -122,13 +122,13 @@ parameters:
         package: msopenjdk-21
         image: "image-repository"
         tag: "3.0"
-      mariner_21:
-        new_LTS_image: false
-        distro: mariner
-        version: 21
-        package: msopenjdk-21
-        image: "image-repository"
-        tag: "2.0"
+      # mariner_21:
+      #   new_LTS_image: false
+      #   distro: mariner
+      #   version: 21
+      #   package: msopenjdk-21
+      #   image: "image-repository"
+      #   tag: "2.0"
       distroless_21:
         new_LTS_image: false
         distro: distroless
@@ -199,7 +199,13 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/build-image.sh
                 displayName: build image
                 env:
-                  REGISTRY_TAG: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
+                  $[ if eq(variables.distro, 'azurelinux') ]:
+                    REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner
+                  # Mariner is reaching EOL, this will be removed in July 2025
+                  # $[ elseif eq(variables.distro, 'mariner') ]:
+                  #   REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner-cm2
+                  $[ else ]:
+                    REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)
                   TAG: $(tag)
                   PACKAGE: $(package)
@@ -256,7 +262,10 @@ extends:
                   scriptPath: $(Build.SourcesDirectory)/scripts/image-annotation.sh
                 env:
                   ACR_NAME: msopenjdk
-                  REGISTRY: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  $[ if eq(variables.distro, 'azurelinux') ]:
+                    REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
+                  $[ else ]:
+                    REGISTRIES: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
 
               - task: AzureCLI@2
                 inputs:
@@ -266,7 +275,14 @@ extends:
                   scriptPath: scripts/build-image.sh
                 displayName: build image
                 env:
-                  REGISTRY_TAG: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
+                  $[ if eq(variables.distro, 'azurelinux') ]:
+                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro);REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner
+                  # Mariner is reaching EOL, this will be removed in July 2025
+                  # $[ elseif eq(variables.distro, 'mariner') ]:
+                  #   REGISTRY_TAGS: REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-mariner-cm2
+                  $[ else ]:
+                    REGISTRY_TAGS: msopenjdk.azurecr.io/public/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)
                   TAG: $(tag)
                   PACKAGE: $(package)
@@ -291,3 +307,22 @@ extends:
                       --parameters openjdk_tags="- $(version)-$(distro)" \
                         image_registry="msopenjdk.azurecr.io/public/openjdk" \
                         image_name="jdk"
+
+               - $[ if eq(variables.distro, 'azurelinux') ]:
+                - task: AzureCLI@2
+                  displayName: Trigger image signing for mariner
+                  env:
+                    AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+                  inputs:
+                    azureSubscription: "JEG-Infrastructure"
+                    scriptType: "bash"
+                    scriptLocation: "inlineScript"
+                    inlineScript: |
+                      az pipelines run \
+                        --branch main \
+                        --org ${{ parameters.organization }} \
+                        --project $(OPENJDK_PROJECT) \
+                        --id $(OPENJDK_SIGNING_ID) \
+                        --parameters openjdk_tags="- $(version)-mariner" \
+                          image_registry="msopenjdk.azurecr.io/public/openjdk" \
+                          image_name="jdk"

--- a/.devops/build.yml
+++ b/.devops/build.yml
@@ -172,7 +172,7 @@ extends:
                 displayName: build image
                 env:
                   ${{ if eq(variables.distro, 'azurelinux') }}:
-                    REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro);msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-mariner
+                    REGISTRY_TAGS: test
                   ${{ else }}:
                     REGISTRY_TAGS: msopenjdk.azurecr.io/internal/private/openjdk/jdk:$(version)-$(distro)
                   IMAGE: $(image)

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        baseimage: ["azurelinux", "mariner", "distroless"]
+        baseimage: ["azurelinux", "distroless"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         jdkversion: [11, 17, 21] # Only build LTS releases
-        baseimage: ["azurelinux", "mariner", "ubuntu", "distroless"]
+        baseimage: ["azurelinux", "ubuntu", "distroless"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -12,7 +12,7 @@ ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-11-linux-ARCH.tar.gz"
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -1,25 +1,29 @@
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="11"
 ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
-ARG INSTALLER_TAG="3.0"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
 ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
-ARG BASE_TAG="3.0"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-11-linux-ARCH.tar.gz"
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -57,3 +61,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.msopenjdk-11-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-11-jdk
@@ -1,7 +1,7 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="3.0"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="3.0"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -1,25 +1,29 @@
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="17"
 ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
-ARG INSTALLER_TAG="3.0"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
 ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
-ARG BASE_TAG="3.0"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-17-linux-ARCH.tar.gz"
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -57,3 +61,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -12,7 +12,7 @@ ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-17-linux-ARCH.tar.gz"
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/distroless/Dockerfile.msopenjdk-17-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-17-jdk
@@ -1,7 +1,7 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="3.0"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="3.0"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -1,25 +1,29 @@
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="21"
 ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
-ARG INSTALLER_TAG="3.0"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
 ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
-ARG BASE_TAG="3.0"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-21-linux-ARCH.tar.gz"
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
-    && rootOrAppRegex='^\(root\|app\):' \
-    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
-    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
 
 # Get JDK
 RUN mkdir -p /usr/lib/jvm && \
@@ -57,3 +61,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -12,7 +12,7 @@ ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-21-linux-ARCH.tar.gz"
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/distroless/Dockerfile.msopenjdk-21-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-21-jdk
@@ -1,7 +1,7 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="3.0"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="3.0"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -1,21 +1,25 @@
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="8"
 ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
-ARG INSTALLER_TAG="3.0"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
 ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
-ARG BASE_TAG="3.0"
+ARG BASE_TAG="${LINUX_VERSION}"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 
-ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/ARCH/jdk/hotspot/normal/eclipse?project=jdk"
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ga/linux/ARCH/jdk/hotspot/normal/eclipse?project=jdk"
 
 # Add dynamically linked packages: zlib
 # Distroless base image already has tzdata ca-certificates openssl glibc
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
-    && adduser --uid 101 --gid 101 --shell /bin/false --system app \
+    && adduser --uid 101 --gid 101 --shell /bin/false --system --create-home app \
     && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
@@ -56,3 +60,4 @@ ENV JAVA_HOME=/usr/jdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 
 ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -12,7 +12,7 @@ ARG JDK_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/ARCH/jdk/hotsp
 # Create a non-root user and group (just like .NET's image)
 RUN mkdir /staging \
     && tdnf update -y \
-    && tdnf install -y --releasever=2.0 --installroot /staging zlib \
+    && tdnf install -y --releasever=3.0 --installroot /staging zlib \
     && tdnf install -y gawk shadow-utils ca-certificates tar \
     && groupadd --system --gid=101 app \
     && adduser --uid 101 --gid 101 --shell /bin/false --system app \

--- a/docker/distroless/Dockerfile.temurin-8-jdk
+++ b/docker/distroless/Dockerfile.temurin-8-jdk
@@ -1,7 +1,7 @@
-ARG INSTALLER_IMAGE="mcr.microsoft.com/cbl-mariner/base/core"
-ARG INSTALLER_TAG="2.0"
-ARG BASE_IMAGE="mcr.microsoft.com/cbl-mariner/distroless/base"
-ARG BASE_TAG="2.0"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="3.0"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="3.0"
 
 FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
 

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -14,4 +14,5 @@ REGISTRY_TAGS="-t ${REGISTRY_TAGS/;/ -t }"
 
 # To push to a registry use --push
 # To build locally use --output=type=image,push=false
+echo "docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --output=type=image,push=false"
 docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --output=type=image,push=false

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -14,5 +14,5 @@ REGISTRY_TAGS="-t ${REGISTRY_TAGS/;/ -t }"
 
 # To push to a registry use --push
 # To build locally use --output=type=image,push=false
-echo "docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --output=type=image,push=false"
-docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --output=type=image,push=false
+echo "docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --push"
+docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --push

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -10,4 +10,6 @@ else
     BUILD_ARGS="--build-arg INSTALLER_IMAGE=$INSTALLER_IMAGE --build-arg INSTALLER_TAG=$INSTALLER_TAG --build-arg BASE_IMAGE=$(base_image) --build-arg BASE_TAG=$(base_tag) --build-arg package=$PACKAGE"
 fi
 
-docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} -t $REGISTRY_TAG -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --push
+REGISTRY_TAGS="-t ${REGISTRY_TAGS/;/ -t }"
+
+docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --push

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -12,4 +12,6 @@ fi
 
 REGISTRY_TAGS="-t ${REGISTRY_TAGS/;/ -t }"
 
-docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --push
+# To push to a registry use --push
+# To build locally use --output=type=image,push=false
+docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_ARGS} ${REGISTRY_TAGS} -f docker/$DISTRIBUTION/Dockerfile.$PACKAGE-jdk . --output=type=image,push=false

--- a/scripts/image-annotation.sh
+++ b/scripts/image-annotation.sh
@@ -6,7 +6,7 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-FS=';' read -ra REGISTRIES_ARRAY <<< "$REGISTRIES"
+IFS=';' read -ra REGISTRIES_ARRAY <<< "$REGISTRIES"
 
 for REGISTRY in "${REGISTRIES_ARRAY[@]}"; do
     echo "Pulling... $REGISTRY"


### PR DESCRIPTION
Deprecate Mariner 2.0 according to our [post](https://devblogs.microsoft.com/java/important-updates-to-container-images-of-microsoft-build-of-openjdk/). This PR:

- Updates distroless images to Azurelinux 3.0 
- Mariner now points to Azurelinux
- Mariner was removed from build and CM2 tag has been introduced

Tests: 
- Upgrade Mariner image and create CM2 image: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11881096&view=results
- Build Distroless image: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11881960&view=results