### PR TITLE
Bump versions to new LTS versions

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         distros: [ "azurelinux", "mariner", "distroless" ]
         jdkvendor: [ "temurin" ]
-        jdkversion: [ { major: "8", expected: "1.8.0_452" } ]
+        jdkversion: [ { major: "8", expected: "1.8.0_462" } ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -40,7 +40,7 @@ jobs:
       matrix:
         distros: [ "azurelinux", "mariner", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.27" }, { major: "17", expected: "17.0.15" }, { major: "21", expected: "21.0.7" } ]
+        jdkversion: [ { major: "11", expected: "11.0.28" }, { major: "17", expected: "17.0.16" }, { major: "21", expected: "21.0.8" } ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         distros: ["azurelinux", "mariner", "distroless"]
         jdkvendor: ["temurin"]
-        jdkversion: [{ major: "8", expected: "1.8.0_452" }]
+        jdkversion: [{ major: "8", expected: "1.8.0_462" }]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -35,9 +35,9 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.27" },
-            { major: "17", expected: "17.0.15" },
-            { major: "21", expected: "21.0.7" },
+            { major: "11", expected: "11.0.28" },
+            { major: "17", expected: "17.0.16" },
+            { major: "21", expected: "21.0.8" },
           ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -59,9 +59,9 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.27" },
-            { major: "17", expected: "17.0.15" },
-            { major: "21", expected: "21.0.7" },
+            { major: "11", expected: "11.0.28" },
+            { major: "17", expected: "17.0.16" },
+            { major: "21", expected: "21.0.8" },
           ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This includes changes to the check-version.yml as well. Though with the recent changes with mariner and azurelinux the expected versions will be different. The local build will use the mariner dockerfile which will be building Mariner CM2 which will not have the latest build of OpenJDK on it.

We could add support to check the previous version or we could deprecate this action. It does not appear to have been used in previous releases regardless.