### PR TITLE
Add JDK25 Dockerfile(s)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdkversion: [11, 17, 21] # Only build LTS releases
+        jdkversion: [11, 17, 21, 25] # Only build LTS releases
         baseimage: ["azurelinux", "ubuntu", "distroless"]
 
     steps:

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         distros: [ "azurelinux", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.28" }, { major: "17", expected: "17.0.16" }, { major: "21", expected: "21.0.8" } ]
+        jdkversion: [ { major: "11", expected: "11.0.28" }, { major: "17", expected: "17.0.16" }, { major: "21", expected: "21.0.8" }, { major: "25", expected: "25.0.0" }]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -38,6 +38,7 @@ jobs:
             { major: "11", expected: "11.0.28" },
             { major: "17", expected: "17.0.16" },
             { major: "21", expected: "21.0.8" },
+            { major: "25", expected: "25.0.0" }
           ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -62,6 +63,7 @@ jobs:
             { major: "11", expected: "11.0.28" },
             { major: "17", expected: "17.0.16" },
             { major: "21", expected: "21.0.8" },
+            { major: "25", expected: "25.0.0" }
           ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/docker/azurelinux/Dockerfile.msopenjdk-25-jdk
+++ b/docker/azurelinux/Dockerfile.msopenjdk-25-jdk
@@ -1,0 +1,24 @@
+ARG IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG TAG="3.0"
+FROM ${IMAGE}:${TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+ARG package="msopenjdk-25"
+ARG PKGS="tzdata ca-certificates freetype shadow-utils"
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-25
+
+RUN tdnf update -y && \
+    tdnf install -y ${package} ${PKGS} && \
+    tdnf clean all && \
+    groupadd --system --gid=101 app && \
+    adduser --uid 101 --gid 101 --system app && \
+    install -d -m 0755 -o 101 -g 101 "/home/app" && \
+    rm -rf /var/cache/tdnf && \
+    rm -rf /usr/lib/jvm/${package}/lib/src.zip && \
+    echo java -Xshare:dump && \
+    java -Xshare:dump
+

--- a/docker/distroless/Dockerfile.msopenjdk-25-jdk
+++ b/docker/distroless/Dockerfile.msopenjdk-25-jdk
@@ -1,0 +1,64 @@
+ARG LINUX_VERSION="3.0"
+ARG JDK_VERSION="25"
+ARG INSTALLER_IMAGE="mcr.microsoft.com/azurelinux/base/core"
+ARG INSTALLER_TAG="${LINUX_VERSION}"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/distroless/base"
+ARG BASE_TAG="${LINUX_VERSION}"
+
+FROM ${INSTALLER_IMAGE}:${INSTALLER_TAG} AS installer
+
+# Redeclare ARG to make it available in this build stage
+ARG INSTALLER_TAG
+ARG JDK_VERSION
+ARG JDK_URL="https://aka.ms/download-jdk/microsoft-jdk-${JDK_VERSION}-linux-ARCH.tar.gz"
+
+# Add dynamically linked packages: zlib
+# Distroless base image already has tzdata ca-certificates openssl glibc
+# Create a non-root user and group (just like .NET's image)
+RUN mkdir /staging \
+    && tdnf update -y \
+    && tdnf install -y --releasever=${INSTALLER_TAG} --installroot /staging zlib \
+    && tdnf install -y gawk shadow-utils ca-certificates tar \
+    && groupadd --system --gid=101 app \
+    && useradd -l --uid=101 --gid=101 --shell /bin/false --system --create-home app  \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
+    && cat /etc/passwd | grep '^\(root\|app\):' > "/staging/etc/passwd" \
+    && cat /etc/group | grep '^\(root\|app\):' > "/staging/etc/group"
+
+# Get JDK
+RUN mkdir -p /usr/lib/jvm && \
+    if [ $(uname -m) = "x86_64" ]; then \
+        JDK_URL=${JDK_URL/ARCH/x64}; \
+    else \
+        JDK_URL=${JDK_URL/ARCH/aarch64}; \
+    fi && \
+    curl --silent -L ${JDK_URL} -o /jdk.tar.gz && \
+    tar -xzf /jdk.tar.gz -C / && \
+    rm /jdk.tar.gz && \
+    mv /jdk-2* /usr/jdk
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && rm -rf /usr/jdk/man /usr/jdk/lib/src.zip \
+    && find /staging/var/log -type f -size +0 -delete
+
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+COPY --from=installer /staging/ /
+COPY --from=installer /usr/jdk/ /usr/jdk/
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV JAVA_HOME=/usr/jdk
+ENV PATH="$PATH:$JAVA_HOME/bin"
+
+ENTRYPOINT [ "/usr/jdk/bin/java" ]
+CMD [ "-version" ]

--- a/docker/ubuntu/Dockerfile.msopenjdk-25-jdk
+++ b/docker/ubuntu/Dockerfile.msopenjdk-25-jdk
@@ -1,0 +1,36 @@
+# DisableDockerDetector "Base image is obtained from internal registry"
+ARG IMAGE="ubuntu"
+ARG TAG="22.04"
+FROM ${IMAGE}:${TAG}
+
+LABEL "Author"="Microsoft"
+LABEL "Support"="Microsoft OpenJDK Support <openjdk-support@microsoft.com>"
+
+ARG package=msopenjdk-25
+
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get -qq update && \
+    apt-get -qq upgrade && \
+    apt-get -qq install --no-install-recommends tzdata ca-certificates fontconfig locales apt-transport-https wget binutils && \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get -qq update && \
+    apt-get -qq install $package && \
+    apt-get -qq purge apt-transport-https wget && \
+    apt-get -qq autoremove --purge && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo java -Xshare:dump && \
+    java -Xshare:dump && \
+    if [ $(uname -m) = "x86_64" ]; then ARCH="amd64"; else ARCH="arm64"; fi && \
+    rm -rf ./usr/lib/jvm/msopenjdk-25-${ARCH}/lib/src.zip && \
+    ln -s /usr/lib/jvm/msopenjdk-25-${ARCH} /usr/lib/jvm/msopenjdk-25
+
+RUN groupadd --system --gid=101 app \
+    && adduser --uid 101 --gid 101 --system app \
+    && install -d -m 0755 -o 101 -g 101 "/home/app"
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-25


### PR DESCRIPTION
This change adds in support for OpenJDK25u. The new JDK25 Dockerfiles are based off the JDK21 Dockerfiles.