### PR TITLE
Update to latest LTS version(s).

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -40,7 +40,13 @@ jobs:
       matrix:
         distros: [ "azurelinux", "distroless", "ubuntu" ]
         jdkvendor: [ "msopenjdk" ]
-        jdkversion: [ { major: "11", expected: "11.0.30" }, { major: "17", expected: "17.0.18" }, { major: "21", expected: "21.0.10" }, { major: "25", expected: "25.0.2" }]
+        jdkversion:
+          [
+            { major: "11", expected: "11.0.31" },
+            { major: "17", expected: "17.0.19" },
+            { major: "21", expected: "21.0.11" },
+            { major: "25", expected: "25.0.3" },
+          ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/validate-published-images.yml
+++ b/.github/workflows/validate-published-images.yml
@@ -35,10 +35,10 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.30" },
-            { major: "17", expected: "17.0.18" },
-            { major: "21", expected: "21.0.10" },
-            { major: "25", expected: "25.0.2" }
+            { major: "11", expected: "11.0.31" },
+            { major: "17", expected: "17.0.19" },
+            { major: "21", expected: "21.0.11" },
+            { major: "25", expected: "25.0.3" }
           ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,10 +60,10 @@ jobs:
         jdkvendor: ["msopenjdk"]
         jdkversion:
           [
-            { major: "11", expected: "11.0.30" },
-            { major: "17", expected: "17.0.18" },
-            { major: "21", expected: "21.0.10" },
-            { major: "25", expected: "25.0.2" }
+            { major: "11", expected: "11.0.31" },
+            { major: "17", expected: "17.0.19" },
+            { major: "21", expected: "21.0.11" },
+            { major: "25", expected: "25.0.3" }
           ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This change updates the check version workflows to check for the latest LTS versions built and published during the April PSU.